### PR TITLE
Link to supported versions

### DIFF
--- a/dist/schema.json
+++ b/dist/schema.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Mastodon API",
     "version": "4.5.0",
-    "description": "Unofficial documentation for the Mastodon API. Generated with [mastodon-openapi](https://github.com/abraham/mastodon-openapi) from [0afc571](https://github.com/mastodon/documentation/commit/0afc57159aecf25fd22522e948c07b4fdad332a3).",
+    "description": "Unofficial documentation for the Mastodon API. Generated with [mastodon-openapi](https://github.com/abraham/mastodon-openapi) from [0afc571](https://github.com/mastodon/documentation/commit/0afc57159aecf25fd22522e948c07b4fdad332a3). Targets [supported](https://github.com/mastodon/mastodon/security/policy#supported-versions) Mastodon versions.",
     "license": {
       "name": "GFDL-1.3",
       "url": "https://www.gnu.org/licenses/fdl-1.3.en.html"

--- a/src/generators/SpecBuilder.ts
+++ b/src/generators/SpecBuilder.ts
@@ -39,7 +39,7 @@ class SpecBuilder {
       }
     }
 
-    const description = `Unofficial documentation for the Mastodon API. Generated with [mastodon-openapi](https://github.com/abraham/mastodon-openapi) from [${config.mastodonDocsCommit.substring(0, 7)}](https://github.com/mastodon/documentation/commit/${config.mastodonDocsCommit}).`;
+    const description = `Unofficial documentation for the Mastodon API. Generated with [mastodon-openapi](https://github.com/abraham/mastodon-openapi) from [${config.mastodonDocsCommit.substring(0, 7)}](https://github.com/mastodon/documentation/commit/${config.mastodonDocsCommit}). Targets [supported](https://github.com/mastodon/mastodon/security/policy#supported-versions) Mastodon versions.`;
 
     return {
       openapi: '3.1.0',


### PR DESCRIPTION
Document supported versions https://github.com/mastodon/mastodon/security/policy#supported-versions